### PR TITLE
fix para funcionar com docker-compose 2

### DIFF
--- a/bin/build-images
+++ b/bin/build-images
@@ -39,7 +39,7 @@ then
         * manual command: docker-compose -f docker-compose-php.yml -f docker-compose-nginx.yml build ${serviceName};
         \n";
 
-        docker-compose -f docker-compose-php.yml -f docker-compose-nginx.yml --log-level INFO build ${serviceName};
+        docker-compose -f docker-compose-php.yml -f docker-compose-nginx.yml build ${serviceName};
 
         if [ $? -eq 0 ]; then
             printf ">> Successfully builded image [${serviceName}] ${CO_VERSION}\n";


### PR DESCRIPTION
A versao 2.0 do docker-compose não suporta o parametro --log-level, gerando um erro que encerra a execução